### PR TITLE
Add button maps for more vpc devices

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -58,8 +58,14 @@ At the time of writing the folder includes `Generic.buttonMap`, which has every 
 - VKB STECS Space Throttle Grip Mini Plus (Right)
 - VKB STECS Space Throttle Grip Standard (Left)
 - VKB STECS Space Throttle Grip Standard (Right)
+- VPC Control Panel 3 (Right side)
+- VPC MT-50CM3 with Constellation Alpha (Right hand, no side/center)
+- VPC Rudder Pedals ACE
 - VPC Throttle MT-50CM3 (Left)
+- VPC VMAX Prime Throttle (Left side)
 - VPC WarBRD Constellation Alpha Prime (Right)
+- VPC WarBRD-D with Constellation Alpha Prime (Left hand and side)
+- VPC WarBRD-D with Constellation Alpha Prime (Right hand and side)
 - WinWing/WINCTRL MFD
 - Winwing/WINCTRL Orion Throttle Base II + F15EX HANDLE L + F15EX HANDLE R (Left)
 

--- a/files/INTO Bindings/DeviceButtonMaps/334401F8.buttonMap
+++ b/files/INTO Bindings/DeviceButtonMaps/334401F8.buttonMap
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- VPC Rudder Pedals ACE -->
+<Root>
+	<!-- Toe Brake Axes Right, Left -->
+	<Joy_UAxis>Toe Brake Right</Joy_UAxis>
+	<Joy_VAxis>Toe Brake Left</Joy_VAxis>
+	<!-- Rudder Axis -->
+	<Joy_ZAxis>[xb1htsRudAx]</Joy_ZAxis>
+
+	<!-- Toe Brake Axes Right, Left -->
+	<!-- Release -->
+	<Pos_Joy_UAxis>Toe Brake Release Right</Pos_Joy_UAxis>
+	<Pos_Joy_VAxis>Toe Brake Release Left</Pos_Joy_VAxis>
+	<!-- Rudder Axis Counter-Clockwise -->
+	<Pos_Joy_ZAxis>[xb1htsRudAx+]</Pos_Joy_ZAxis>
+
+	<!-- Toe Brake Axes Right, Left -->
+	<!-- Push -->
+	<Neg_Joy_UAxis>Toe Brake Push Right</Neg_Joy_UAxis>
+	<Neg_Joy_VAxis>Toe Brake Push Left</Neg_Joy_VAxis>
+	<!-- Rudder Axis Clockwise -->
+	<Neg_Joy_ZAxis>[xb1htsRudAx-]</Neg_Joy_ZAxis>
+</Root>

--- a/files/INTO Bindings/DeviceButtonMaps/33440388.buttonMap
+++ b/files/INTO Bindings/DeviceButtonMaps/33440388.buttonMap
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- VPC Stick MT-50CM3 with Constellation Alpha (Right) -->
+<Root>
+	<!-- Analogue Mini-Stick Axes -->
+	<!-- X, Y -->
+	<Joy_RXAxis>Alpha [ps4RXAxis]</Joy_RXAxis>
+	<Joy_RYAxis>Alpha [ps4RYAxis]</Joy_RYAxis>
+	<!-- Brake Lever Axis -->
+	<Joy_UAxis>Alpha Brake [x52prob6]</Joy_UAxis>
+	<!-- Base Axes -->
+	<!-- X, Y -->
+	<Joy_XAxis>CM3 [x52prox]</Joy_XAxis>
+	<Joy_YAxis>CM3 [x52proy]</Joy_YAxis>
+	<!-- Twist Axis -->
+	<Joy_ZAxis>Alpha [x52prorz]</Joy_ZAxis>
+
+	<!-- Analogue Mini-Stick Axes -->
+	<!--Right, Down -->
+	<Pos_Joy_RXAxis>Alpha [ps4RThumbR]</Pos_Joy_RXAxis>
+	<Pos_Joy_RYAxis>Alpha [ps4RThumbD]</Pos_Joy_RYAxis>
+	<!-- Brake Lever Axis Pull -->
+	<Pos_Joy_UAxis>Alpha Brake [x52prob6]</Pos_Joy_UAxis>
+	<!-- Base Axes -->
+	<!-- Right, Down -->
+	<Pos_Joy_XAxis>CM3 [x52prox+]</Pos_Joy_XAxis>
+	<Pos_Joy_YAxis>CM3 [x52proy-]</Pos_Joy_YAxis>
+	<!-- Twist Axis Clockwise -->
+	<Pos_Joy_ZAxis>Alpha [x52prorz+]</Pos_Joy_ZAxis>
+
+	<!-- Analogue Mini-Stick Axes -->
+	<!-- Left, Up -->
+	<Neg_Joy_RXAxis>Alpha [ps4RThumbL]</Neg_Joy_RXAxis>
+	<Neg_Joy_RYAxis>Alpha [ps4RThumbU]</Neg_Joy_RYAxis>
+	<!-- Brake Lever Axis Release -->
+	<Neg_Joy_UAxis>Alpha Brake [x52prob6]</Neg_Joy_UAxis>
+	<!-- Base Axes -->
+	<!-- Left, Up -->
+	<Neg_Joy_XAxis>CM3 [x52prox-]</Neg_Joy_XAxis>
+	<Neg_Joy_YAxis>CM3 [x52proy+]</Neg_Joy_YAxis>
+	<!-- Twist Axis Counter-Clockwise -->
+	<Neg_Joy_ZAxis>Alpha [x52prorz-]</Neg_Joy_ZAxis>
+
+	<!-- Flip Trigger -->
+	<!-- Up, Pull -->
+	<Joy_1>Alpha Flip [x52prob1] - Up</Joy_1>
+	<Joy_2>Alpha Flip [x52prob1] - Pull</Joy_2>
+	<!-- Dual-Stage Trigger -->
+	<!-- Stage 1, Stage 2 -->
+	<Joy_3>Alpha [x52prob1] - Stage 1</Joy_3>
+	<Joy_4>Alpha [x52prob15] - Stage 2</Joy_4>
+
+	<!-- Analogue Mini-Stick Push -->
+	<Joy_5>Alpha [ps4RThumb]</Joy_5>
+
+	<!-- Momentary Button Black -->
+	<Joy_6>Alpha [x52prob4]</Joy_6>
+
+	<!-- 4-way Hat Face Bottom-Left -->
+	<!-- Push, Up, Right, Down, Left -->
+	<Joy_7>Alpha Face [x52prob26] Push</Joy_7>
+	<Joy_8>Alpha Face [x52prob24]</Joy_8>
+	<Joy_9>Alpha Face [x52prob25]</Joy_9>
+	<Joy_10>Alpha Face [x52prob26]</Joy_10>
+	<Joy_11>Alpha Face [x52prob27]</Joy_11>
+
+	<!-- Momentary Button Red -->
+	<Joy_12>Alpha [x52prob3]</Joy_12>
+
+	<!-- 4-way Hat Face Top-Right -->
+	<!-- Push, Up, Right, Down, Left -->
+	<Joy_13>Alpha [x52prop1d] Push</Joy_13>
+	<Joy_14>Alpha [x52prop1u]</Joy_14>
+	<Joy_15>Alpha [x52prop1r]</Joy_15>
+	<Joy_16>Alpha [x52prop1d]</Joy_16>
+	<Joy_17>Alpha [x52prop1l]</Joy_17>
+
+	<!-- 2-way Hat Index Side -->
+	<!-- Push, Up, Down -->
+	<Joy_18>Alpha Index [x52b22] Push</Joy_18>
+	<Joy_19>Alpha Index [x52b20]</Joy_19>
+	<Joy_20>Alpha Index [x52b22]</Joy_20>
+
+	<!-- Scroll Encoder -->
+	<!-- Push1, Push 2, Down, Up -->
+	<Joy_21>Alpha [x52prob19] Push 1</Joy_21>
+	<Joy_22>Alpha [x52prob19] Push 2</Joy_22>
+	<Joy_23>Alpha [x52prob19] Down</Joy_23>
+	<Joy_24>Alpha [x52prob19] Up</Joy_24>
+
+	<!-- 4-way Hat Thumb Side -->
+	<!-- Push, Up, Right, Down, Left -->
+	<Joy_25>Alpha Side [x52prob26] Push</Joy_25>
+	<Joy_26>Alpha Side [x52prob24]</Joy_26>
+	<Joy_27>Alpha Side [x52prob25]</Joy_27>
+	<Joy_28>Alpha Side [x52prob26]</Joy_28>
+	<Joy_29>Alpha Side [x52prob27]</Joy_29>
+
+	<!-- Momentary Button Pinkie -->
+	<Joy_30>Alpha [x52prob5]</Joy_30>
+
+	<!-- Brake Lever Momentary Button -->
+	<Joy_31>Alpha Brake [x52prob6]</Joy_31>
+</Root>

--- a/files/INTO Bindings/DeviceButtonMaps/3344425C.buttonMap
+++ b/files/INTO Bindings/DeviceButtonMaps/3344425C.buttonMap
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- RIGHT VPC Control Panel 3 -->
+<Root>
+	<!-- Lever Axes Black, Yellow, Blue, Red -->
+	<Joy_XAxis>CP3 [x52prou] Black</Joy_XAxis>
+	<Joy_YAxis>CP3 [x52prou] Yellow</Joy_YAxis>
+	<Joy_RXAxis>CP3 [x52prou] Blue</Joy_RXAxis>
+	<Joy_RYAxis>CP3 [x52prou] Red</Joy_RYAxis>
+
+	<!-- Lever Axes Up Black, Yellow, Blue, Red -->
+	<Pos_Joy_XAxis>CP3 [x52prou+] Black</Pos_Joy_XAxis>
+	<Pos_Joy_YAxis>CP3 [x52prou+] Yellow</Pos_Joy_YAxis>
+	<Pos_Joy_RXAxis>CP3 [x52prou+] Blue</Pos_Joy_RXAxis>
+	<Pos_Joy_RYAxis>CP3 [x52prou+] Red</Pos_Joy_RYAxis>
+
+	<!-- Lever Axes Down Black, Yellow, Blue, Red -->
+	<Neg_Joy_XAxis>CP3 [x52prou-] Black</Neg_Joy_XAxis>
+	<Neg_Joy_YAxis>CP3 [x52prou-] Yellow</Neg_Joy_YAxis>
+	<Neg_Joy_RXAxis>CP3 [x52prou-] Blue</Neg_Joy_RXAxis>
+	<Neg_Joy_RYAxis>CP3 [x52prou-] Red</Neg_Joy_RYAxis>
+
+	<!-- Buttons B1, B2, B3, B4, B5, B6, B7, B8, B9, B10, B11, B12, B13 -->
+	<Joy_1>CP3 B1</Joy_1>
+	<Joy_2>CP3 B2</Joy_2>
+	<Joy_3>CP3 B3</Joy_3>
+	<Joy_4>CP3 B4</Joy_4>
+	<Joy_5>CP3 B5</Joy_5>
+	<Joy_6>CP3 B6</Joy_6>
+	<Joy_7>CP3 B7</Joy_7>
+	<Joy_8>CP3 B8</Joy_8>
+	<Joy_9>CP3 B9</Joy_9>
+	<Joy_10>CP3 B10</Joy_10>
+	<Joy_11>CP3 B11</Joy_11>
+	<Joy_12>CP3 B12</Joy_12>
+	<Joy_13>CP3 B13</Joy_13>
+
+	<!-- Latching Toggle Switch T1 -->
+	<!-- Up, Mid, Down -->
+	<Joy_14>CP3 T1 - Up</Joy_14>
+	<Joy_15>CP3 T1 - Mid</Joy_15>
+	<Joy_16>CP3 T1 - Down</Joy_16>
+
+	<!-- Toggle Switches T2, T3, T4, T5, T6, T7, T8 -->
+	<!-- each Up, Down -->
+	<Joy_17>CP3 T2 - Up</Joy_17>
+	<Joy_18>CP3 T2 - Down</Joy_18>
+	<Joy_19>CP3 T3 - Up</Joy_19>
+	<Joy_20>CP3 T3 - Down</Joy_20>
+	<Joy_21>CP3 T4 - Up</Joy_21>
+	<Joy_22>CP3 T4 - Down</Joy_22>
+	<Joy_23>CP3 T5 - Up</Joy_23>
+	<Joy_24>CP3 T5 - Down</Joy_24>
+	<Joy_25>CP3 T6 - Up</Joy_25>
+	<Joy_26>CP3 T6 - Down</Joy_26>
+	<Joy_27>CP3 T7 - Up</Joy_27>
+	<Joy_28>CP3 T7 - Down</Joy_28>
+	<Joy_29>CP3 T8 - Up</Joy_29>
+	<Joy_30>CP3 T8 - Down</Joy_30>
+
+	<!-- Latching Toggle Switch L | R (horizontal)-->
+	<!-- Left, Center, Right -->
+	<Joy_31>CP3 TH - L</Joy_31>
+	<Joy_32>CP3 TH - |</Joy_32>
+	<Joy_33>CP3 TH - R</Joy_33>
+
+	<!-- Latching Toggle Switch MASTER ARM -->
+	<!-- Up, Mid, Down -->
+	<Joy_34>CP3 MASTER ARM - Up</Joy_34>
+	<Joy_35>CP3 MASTER ARM - Mid</Joy_35>	
+	<Joy_36>CP3 MASTER ARM - Down</Joy_36>
+
+	<!-- Scroll Encoder Dials E1, E2 -->
+	<!-- each Push, Counter-Clockwise, Clockwise -->
+	<Joy_37>CP3 [x52prob8] 1</Joy_37>
+	<Joy_38>CP3 [x52prory-] 1</Joy_38>
+	<Joy_39>CP3 [x52prory+] 1</Joy_39>
+	<Joy_40>CP3 [x52prob8] 2</Joy_40>
+	<Joy_41>CP3 [x52prory-] 2</Joy_41>
+	<Joy_42>CP3 [x52prory+] 2</Joy_42>
+
+	<!-- MODE Dial 1, 2, 3, 4, 5 -->
+	<Joy_43>CP3 MODE - 1</Joy_43>
+	<Joy_44>CP3 MODE - 2</Joy_44>
+	<Joy_45>CP3 MODE - 3</Joy_45>
+	<Joy_46>CP3 MODE - 4</Joy_46>
+	<Joy_47>CP3 MODE - 5</Joy_47>
+</Root>

--- a/files/INTO Bindings/DeviceButtonMaps/334443F5.buttonMap
+++ b/files/INTO Bindings/DeviceButtonMaps/334443F5.buttonMap
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- RIGHT VPC Stick WarBRD-D with Constellation Alpha Prime (Right) -->
+<Root>
+	<!-- Analogue Mini-Stick Axes -->
+	<!-- X, Y -->
+	<Joy_RXAxis>Alpha R [ps4RXAxis]</Joy_RXAxis>
+	<Joy_RYAxis>Alpha R [ps4RYAxis]</Joy_RYAxis>
+	<!-- Brake Lever Axis -->
+	<Joy_UAxis>Alpha R Brake [x52prob6]</Joy_UAxis>
+	<!-- Base Axes -->
+	<!-- X, Y -->
+	<Joy_XAxis>WarBRD-D R [x52prox]</Joy_XAxis>
+	<Joy_YAxis>WarBRD-D R [x52proy]</Joy_YAxis>
+	<!-- Twist Axis -->
+	<Joy_ZAxis>Alpha R [x52prorz]</Joy_ZAxis>
+
+	<!-- Analogue Mini-Stick Axes -->
+	<!-- Right, Down -->
+	<Pos_Joy_RXAxis>Alpha R [ps4RThumbR]</Pos_Joy_RXAxis>
+	<Pos_Joy_RYAxis>Alpha R [ps4RThumbD]</Pos_Joy_RYAxis>
+	<!-- Brake Lever Axis Pull -->
+	<Pos_Joy_UAxis>Alpha R Brake [x52prob6]</Pos_Joy_UAxis>
+	<!-- Base Axes -->
+	<!-- Right, Down -->
+	<Pos_Joy_XAxis>WarBRD-D R [x52prox+]</Pos_Joy_XAxis>
+	<Pos_Joy_YAxis>WarBRD-D R [x52proy-]</Pos_Joy_YAxis>
+	<!-- Twist Axis Clockwise -->
+	<Pos_Joy_ZAxis>Alpha R [x52prorz+]</Pos_Joy_ZAxis>
+
+	<!-- Analogue Mini-Stick Axes -->
+	<!-- Left, Up -->
+	<Neg_Joy_RXAxis>Alpha R [ps4RThumbL]</Neg_Joy_RXAxis>
+	<Neg_Joy_RYAxis>Alpha R [ps4RThumbU]</Neg_Joy_RYAxis>
+	<!-- Brake Lever Axis Release -->
+	<Neg_Joy_UAxis>Alpha R Brake [x52prob6]</Neg_Joy_UAxis>
+	<!-- Base Axes -->
+	<!-- Left, Up -->
+	<Neg_Joy_XAxis>WarBRD-D R [x52prox-]</Neg_Joy_XAxis>
+	<Neg_Joy_YAxis>WarBRD-D R [x52proy+]</Neg_Joy_YAxis>
+	<!-- Twist Axis Counter-Clockwise -->
+	<Neg_Joy_ZAxis>Alpha R [x52prorz-]</Neg_Joy_ZAxis>
+
+	<!-- Dual-Position Flip Trigger -->
+	<!-- Up, Center, Pull -->
+	<Joy_1>Alpha R Flip [x52prob1] Up</Joy_1>
+	<Joy_2>Alpha R Flip [x52prob1] Center</Joy_2>
+	<Joy_3>Alpha R Flip [x52prob1] Pull</Joy_3>
+	<!-- Dual-Stage Trigger -->
+	<!-- Stage 1, Stage 2 -->
+	<Joy_4>Alpha R [x52prob1] Stage 1</Joy_4>
+	<Joy_5>Alpha R [x52prob15] Stage 2</Joy_5>
+
+	<!-- Analogue Mini-Stick Push -->
+	<Joy_6>Alpha R [ps4RThumb]</Joy_6>
+
+	<!-- Momentary Button Face Top-Left -->
+	<Joy_7>Alpha R [x52prob3]</Joy_7>
+
+	<!-- 4-way Hat Face Top-Right -->
+	<!-- Push, Up, Left, Down, Right -->
+	<Joy_8>Alpha R [x52prob22] Push</Joy_8>
+	<Joy_9>Alpha R [x52prob20]</Joy_9>
+	<Joy_10>Alpha R [x52prob23]</Joy_10>
+	<Joy_11>Alpha R [x52prob22]</Joy_11>
+	<Joy_12>Alpha R [x52prob21]</Joy_12>
+
+	<!-- Momentary Button Face Bottom-Right -->
+	<Joy_13>Alpha R [x52prob4]</Joy_13>
+
+	<!-- 4-way Hat Face Bottom-Left -->
+	<!-- Push, Up, Left, Down, Right -->
+	<Joy_14>Alpha R [x52b22] Push</Joy_14>
+	<Joy_15>Alpha R [x52b20]</Joy_15>
+	<Joy_16>Alpha R [x52b23]</Joy_16>
+	<Joy_17>Alpha R [x52b22]</Joy_17>
+	<Joy_18>Alpha R [x52b21]</Joy_18>
+
+	<!-- Scroll Encoder -->
+	<!-- Push 1, Push 2, Up, Down -->
+	<Joy_19>Alpha R [x52prob19] Push 1</Joy_19>
+	<Joy_20>Alpha R [x52prob19] Push 2</Joy_20>
+	<Joy_21>Alpha R [x52prob19] Up</Joy_21>
+	<Joy_22>Alpha R [x52prob19] Down</Joy_22>
+
+	<!-- 4-way Hat Thumb Side -->
+	<!-- Push, Up, Left, Down, Right -->
+	<Joy_23>Alpha R [x52prob26] Push</Joy_23>
+	<Joy_24>Alpha R [x52prob24]</Joy_24>
+	<Joy_25>Alpha R [x52prob27]</Joy_25>
+	<Joy_26>Alpha R [x52prob26]</Joy_26>
+	<Joy_27>Alpha R [x52prob25]</Joy_27>
+
+	<!-- 2-way Hat Index Side -->
+	<!-- Push, Up, Down -->
+	<Joy_28>Alpha R Index [x52b22] Push</Joy_28>
+	<Joy_29>Alpha R Index [x52b20]</Joy_29>
+	<Joy_30>Alpha R Index [x52b22]</Joy_30>
+
+	<!-- Momentary Button Pinkie -->
+	<Joy_31>Alpha R [x52prob5]</Joy_31>
+
+	<!-- Brake Lever Momentary Button -->
+	<Joy_32>Alpha R Brake [x52prob6]</Joy_32>
+</Root>

--- a/files/INTO Bindings/DeviceButtonMaps/33448196.buttonMap
+++ b/files/INTO Bindings/DeviceButtonMaps/33448196.buttonMap
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- LEFT VPC VMAX Prime Throttle -->
+<Root>
+	<!-- Throttle Axes Left, Right -->
+	<Joy_RXAxis>VMAX [x52proz] L</Joy_RXAxis>
+	<Joy_RYAxis>VMAX [x52proz] R</Joy_RYAxis>
+	<!-- Flaps Axis / MVR -->
+	<Joy_RZAxis>VMAX [x52prou]</Joy_RZAxis>
+	<!-- Dial Axes Left, Top -->
+	<Joy_UAxis>VMAX [x52prorx] Left</Joy_UAxis>
+	<Joy_VAxis>VMAX [x52prorx] Top</Joy_VAxis>
+	<!-- Mini-Stick Axes X, Y -->
+	<Joy_XAxis>VMAX [ps4RXAxis]</Joy_XAxis>
+	<Joy_YAxis>VMAX [ps4RYAxis]</Joy_YAxis>
+
+	<!-- Throttle Axis Left, Right -->
+	<!-- MAX -->
+	<Pos_Joy_RXAxis>VMAX [x52proz+] L</Pos_Joy_RXAxis>
+	<Pos_Joy_RYAxis>VMAX [x52proz+] R</Pos_Joy_RYAxis>
+	<!-- Flaps Axis / MVR UP -->
+	<Pos_Joy_RZAxis>VMAX [x52prou+]</Pos_Joy_RZAxis>
+	<!-- Dial Axis Left Counter-Clockwise -->
+	<Pos_Joy_UAxis>VMAX [x52prorx-] Left</Pos_Joy_UAxis>
+	<!-- Dial Axis Top Clockwise -->
+	<Pos_Joy_VAxis>VMAX [x52prorx+] Top</Pos_Joy_VAxis>
+	<!-- Analogue Mini-Stick Axes -->
+	<!-- Right, Down -->
+	<Pos_Joy_XAxis>VMAX [ps4RThumbR]</Pos_Joy_XAxis>
+	<Pos_Joy_YAxis>VMAX [ps4RThumbD]</Pos_Joy_YAxis>
+
+	<!-- Throttle Axis Left, Right -->
+	<!-- IDLE/OFF -->
+	<Neg_Joy_RXAxis>VMAX [x52proz-] L</Neg_Joy_RXAxis>
+	<Neg_Joy_RYAxis>VMAX [x52proz-] R</Neg_Joy_RYAxis>
+	<!-- Flaps Axis / MVR DN -->
+	<Neg_Joy_RZAxis>VMAX [x52prou-]</Neg_Joy_RZAxis>
+	<!-- Dial Axis Left Clockwise -->
+	<Neg_Joy_UAxis>VMAX [x52prorx+] Left</Neg_Joy_UAxis>
+	<!-- Dial Axis Top Counter-Clockwise -->
+	<Neg_Joy_VAxis>VMAX [x52prorx-] Top</Neg_Joy_VAxis>
+	<!-- Analogue Mini-Stick Axes -->
+	<!-- Left, Up -->
+	<Neg_Joy_XAxis>VMAX [ps4RThumbL]</Neg_Joy_XAxis>
+	<Neg_Joy_YAxis>VMAX [ps4RThumbU]</Neg_Joy_YAxis>
+
+	<!-- Grey Button Pinkie -->
+	<Joy_1>VMAX [x52prob7]</Joy_1>
+
+	<!-- Dial Left Push -->
+	<Joy_2>VMAX [x52prob31] Left</Joy_2>
+
+	<!-- Circle Button Middle Finger -->
+	<Joy_3>VMAX [x52prob4]</Joy_3>
+
+	<!-- 4-Way Hat Index -->
+	<!-- Push, Up, Right, Down, Left -->
+	<Joy_4>VMAX [x52prob26] Push</Joy_4>
+	<Joy_5>VMAX [x52prob24]</Joy_5>
+	<Joy_6>VMAX [x52prob25]</Joy_6>
+	<Joy_7>VMAX [x52prob26]</Joy_7>
+	<Joy_8>VMAX [x52prob27]</Joy_8>
+
+	<!-- Dial Top Push -->
+	<Joy_9>VMAX [x52prob31] Top</Joy_9>
+
+	<!-- 2-Way Hat Thumb Left -->
+	<!-- Push, Up, Down -->
+	<Joy_10>VMAX [x52b22] Push</Joy_10>
+	<Joy_11>VMAX [x52b20]</Joy_11>
+	<Joy_13>VMAX [x52b22]</Joy_13>
+
+	<!-- Mini-Stick Push -->
+	<Joy_15>VMAX [ps4RThumb]</Joy_15>
+
+	<!-- Circle Button Thumb -->
+	<Joy_16>VMAX [x52prob3]</Joy_16>
+	<!-- Grey Button Thumb -->
+	<Joy_17>VMAX [x52prob5]</Joy_17>
+
+	<!-- 4-Way Hat Thumb -->
+	<!-- Push, Up, Right, Down, Left -->
+	<Joy_18>VMAX [x52prob22] Push</Joy_18>
+	<Joy_19>VMAX [x52prob20]</Joy_19>
+	<Joy_20>VMAX [x52prob21]</Joy_20>
+	<Joy_21>VMAX [x52prob22]</Joy_21>
+	<Joy_22>VMAX [x52prob23]</Joy_22>
+
+	<!-- KEYBOARD Buttons B1, B2, B3, B4, B5, B6 -->
+	<Joy_23>VMAX B1</Joy_23>
+	<Joy_24>VMAX B2</Joy_24>
+	<Joy_25>VMAX B3</Joy_25>
+	<Joy_26>VMAX B4</Joy_26>
+	<Joy_27>VMAX B5</Joy_27>
+	<Joy_28>VMAX B6</Joy_28>
+
+	<!-- EMERG STORES JETT Button B7 -->
+	<Joy_29>VMAX STORES JETT B7</Joy_29>
+
+	<!-- Toggle Switches T1, T2, T3, T4, T5 -->
+	<!-- each Up, Down-->
+	<Joy_30>VMAX T1 - Up</Joy_30>
+	<Joy_31>VMAX T1 - Down</Joy_31>
+	<Joy_32>VMAX T2 - Up</Joy_32>
+	<Joy_33>VMAX T2 - Down</Joy_33>
+	<Joy_34>VMAX T3 - Up</Joy_34>
+	<Joy_35>VMAX T3 - Down</Joy_35>
+	<Joy_36>VMAX T4 - Up</Joy_36>
+	<Joy_37>VMAX T4 - Down</Joy_37>
+	<Joy_38>VMAX T5 - Up</Joy_38>
+	<Joy_39>VMAX T5 - Down</Joy_39>
+
+	<!-- APU Button -->
+	<Joy_40>VMAX APU</Joy_40>
+
+	<!-- Encoder Dials E1, E2 -->
+	<!-- each Push, Counter-Clockwise, Clockwise -->
+	<Joy_41>VMAX [x52prob8] 1</Joy_41>
+	<Joy_42>VMAX [x52prory-] 1</Joy_42>
+	<Joy_43>VMAX [x52prory+] 1</Joy_43>
+	<Joy_44>VMAX [x52prob8] 2</Joy_44>
+	<Joy_45>VMAX [x52prory-] 2</Joy_45>
+	<Joy_46>VMAX [x52prory+] 2</Joy_46>
+
+	<!-- MODE Switch Dial 1, 2, 3, 4, 5 -->
+	<Joy_47>VMAX MODE - 1</Joy_47>
+	<Joy_48>VMAX MODE - 2</Joy_48>
+	<Joy_49>VMAX MODE - 3</Joy_49>
+	<Joy_50>VMAX MODE - 4</Joy_50>
+	<Joy_51>VMAX MODE - 5</Joy_51>
+</Root>

--- a/files/INTO Bindings/DeviceButtonMaps/334483F4.buttonMap
+++ b/files/INTO Bindings/DeviceButtonMaps/334483F4.buttonMap
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- LEFT VPC Stick WarBRD-D with Constellation Alpha Prime (Left) -->
+<Root>
+	<!-- Analogue Mini-Stick Axes -->
+	<!-- X, Y -->
+	<Joy_RXAxis>Alpha L [ps4RXAxis]</Joy_RXAxis>
+	<Joy_RYAxis>Alpha L [ps4RYAxis]</Joy_RYAxis>
+	<!-- Brake Lever Axis -->
+	<Joy_UAxis>Alpha L Brake [x52prob6]</Joy_UAxis>
+	<!-- Base Axes -->
+	<!-- X, Y -->
+	<Joy_XAxis>WarBRD-D L [x52prox]</Joy_XAxis>
+	<Joy_YAxis>WarBRD-D L [x52proy]</Joy_YAxis>
+	<!-- Twist Axis -->
+	<Joy_ZAxis>Alpha L [x52prorz]</Joy_ZAxis>
+
+	<!-- Analogue Mini-Stick Axes -->
+	<!-- Right, Down -->
+	<Pos_Joy_RXAxis>Alpha L [ps4RThumbR]</Pos_Joy_RXAxis>
+	<Pos_Joy_RYAxis>Alpha L [ps4RThumbD]</Pos_Joy_RYAxis>
+	<!-- Brake Lever Axis Pull -->
+	<Pos_Joy_UAxis>Alpha L Brake [x52prob6]</Pos_Joy_UAxis>
+	<!-- Base Axes -->
+	<!-- Right, Down -->
+	<Pos_Joy_XAxis>WarBRD-D L [x52prox+]</Pos_Joy_XAxis>
+	<Pos_Joy_YAxis>WarBRD-D L [x52proy-]</Pos_Joy_YAxis>
+	<!-- Twist Axis Clockwise-->
+	<Pos_Joy_ZAxis>Alpha L [x52prorz+]</Pos_Joy_ZAxis>
+
+	<!-- Analogue Mini-Stick Axes -->
+	<!-- Left, Up -->
+	<Neg_Joy_RXAxis>Alpha L [ps4RThumbL]</Neg_Joy_RXAxis>
+	<Neg_Joy_RYAxis>Alpha L [ps4RThumbU]</Neg_Joy_RYAxis>
+	<!-- Brake Lever Axis Release -->
+	<Neg_Joy_UAxis>Alpha L Brake [x52prob6]</Neg_Joy_UAxis>
+	<!-- Base Axes -->
+	<!-- Left, Up -->
+	<Neg_Joy_XAxis>WarBRD-D L [x52prox-]</Neg_Joy_XAxis>
+	<Neg_Joy_YAxis>WarBRD-D L [x52proy+]</Neg_Joy_YAxis>
+	<!-- Twist Axis Counter-Clockwise -->
+	<Neg_Joy_ZAxis>Alpha L [x52prorz-]</Neg_Joy_ZAxis>
+
+	<!-- Dual-Position Flip Trigger -->
+	<!-- Up, Center, Pull -->
+	<Joy_1>Alpha L Flip [x52prob1] Up</Joy_1>
+	<Joy_2>Alpha L Flip [x52prob1] Center</Joy_2>
+	<Joy_3>Alpha L Flip [x52prob1] Pull</Joy_3>
+	<!-- Dual-Stage Trigger -->
+	<!-- Stage 1, Stage 2 -->
+	<Joy_4>Alpha L [x52prob1] Stage 1</Joy_4>
+	<Joy_5>Alpha L [x52prob15] Stage 2</Joy_5>
+
+	<!-- Analogue Mini-Stick Push -->
+	<Joy_6>Alpha L [ps4RThumb]</Joy_6>
+
+	<!-- Momentary Button Face Top-Right -->
+	<Joy_7>Alpha L [x52prob3]</Joy_7>
+
+	<!-- 4-way Hat Face Top-Left -->
+	<!-- Push, Up, Right, Down, Left -->
+	<Joy_8>Alpha L [x52prob22] Push</Joy_8>
+	<Joy_9>Alpha L [x52prob20]</Joy_9>
+	<Joy_10>Alpha L [x52prob21]</Joy_10>
+	<Joy_11>Alpha L [x52prob22]</Joy_11>
+	<Joy_12>Alpha L [x52prob23]</Joy_12>
+
+	<!-- Momentary Button Face Bottom-Left -->
+	<Joy_13>Alpha L [x52prob4]</Joy_13>
+
+	<!-- 4-way Hat Face Bottom-Right -->
+	<!-- Push, Up, Right, Down, Left -->
+	<Joy_14>Alpha L [x52b22] Push</Joy_14>
+	<Joy_15>Alpha L [x52b20]</Joy_15>
+	<Joy_16>Alpha L [x52b21]</Joy_16>
+	<Joy_17>Alpha L [x52b22]</Joy_17>
+	<Joy_18>Alpha L [x52b23]</Joy_18>
+
+	<!-- Scroll Encoder -->
+	<!-- Push 1, Push 2, Up, Down -->
+	<Joy_19>Alpha L [x52prob19] Push 1</Joy_19>
+	<Joy_20>Alpha L [x52prob19] Push 2</Joy_20>
+	<Joy_21>Alpha L [x52prob19] Up</Joy_21>
+	<Joy_22>Alpha L [x52prob19] Down</Joy_22>
+
+	<!-- 4-way Hat Thumb Side -->
+	<!-- Push, Up, Right, Down, Left -->
+	<Joy_23>Alpha L [x52prob26] Push</Joy_23>
+	<Joy_24>Alpha L [x52prob24]</Joy_24>
+	<Joy_25>Alpha L [x52prob25]</Joy_25>
+	<Joy_26>Alpha L [x52prob26]</Joy_26>
+	<Joy_27>Alpha L [x52prob27]</Joy_27>
+
+	<!-- 2-way Hat Index Side -->
+	<!-- Push, Up, Down -->
+	<Joy_28>Alpha L Index [x52b22] Push</Joy_28>
+	<Joy_29>Alpha L Index [x52b20]</Joy_29>
+	<Joy_30>Alpha L Index [x52b22]</Joy_30>
+
+	<!-- Momentary Button Pinkie -->
+	<Joy_31>Alpha L [x52prob5]</Joy_31>
+
+	<!-- Brake Lever Momentary Button -->
+	<Joy_32>Alpha L Brake [x52prob6]</Joy_32>
+</Root>


### PR DESCRIPTION
Added button maps for VPC devices:

- VPC Control Panel 3 (Right side)
- VPC MT-50CM3 with Constellation Alpha (Right hand, no side/center)
- VPC Rudder Pedals ACE
- VPC VMAX Prime Throttle (Left side)
- VPC WarBRD-D with Constellation Alpha Prime (Left hand and side)
- VPC WarBRD-D with Constellation Alpha Prime (Right hand and side)

Also updated devices list in README